### PR TITLE
Bank only uses start address, not end address

### DIFF
--- a/hdl/adpcm/jt10_adpcm_cnt.v
+++ b/hdl/adpcm/jt10_adpcm_cnt.v
@@ -136,7 +136,7 @@ always @(posedge clk or negedge rst_n)
         clr2   <= aoff || aon || done1; // Each time a A-ON is sent the address counter restarts
         start2 <=  (up_start && up1) ? addr_in[11:0] : start1;
         end2   <=  (up_end   && up1) ? addr_in[11:0] : end1;
-        bank2  <= ((up_end | up_start) && up1) ? addr_in[15:12] : bank1;
+        bank2  <=  (up_start && up1) ? addr_in[15:12] : bank1;
         skip2  <= skip1;
 
         addr3  <= addr2; // clr2 ? {start2,9'd0} : addr2;


### PR DESCRIPTION
Lots of documentation states that start and end address need to be in the same bank. However, I haven't read anything that says what happens when this is done against recommendation.  Just found out that Twinkle Star Sprites select screen does this. It sets bank = 3 for the start address, then sets end address to bank 2.  It then expects to play the sample in bank 3.  I take this to mean that only start updates the bank, and the high nibble for end address is never used.  This change fixes the Twinkle Star Sprites song (FC1E).