### PR TITLE
Updates for ADPCMB

### DIFF
--- a/hdl/adpcm/jt10_adpcm_drvB.v
+++ b/hdl/adpcm/jt10_adpcm_drvB.v
@@ -28,6 +28,7 @@ module jt10_adpcm_drvB(
     input           acmd_on_b,  // Control - Process start, Key On
     input           acmd_rep_b, // Control - Repeat
     input           acmd_rst_b, // Control - Reset
+    input           acmd_up_b, // Control - New command received
     input    [ 1:0] alr_b,      // Left / Right
     input    [15:0] astart_b,   // Start address
     input    [15:0] aend_b,     // End   address
@@ -46,6 +47,8 @@ module jt10_adpcm_drvB(
 
 wire nibble_sel;
 wire adv;           // advance to next reading
+wire restart;
+wire chon;
 
 // `ifdef SIMULATION
 // real fsample;
@@ -57,13 +60,14 @@ wire adv;           // advance to next reading
 // end
 // `endif
 
-always @(posedge clk) roe_n <= ~adv;
+always @(posedge clk) roe_n <= ~(adv & cen55);
 
 jt10_adpcmb_cnt u_cnt(
     .rst_n       ( rst_n           ),
     .clk         ( clk             ),
     .cen         ( cen55           ),
     .delta_n     ( adeltan_b       ),
+	 .acmd_up_b   ( acmd_up_b       ),
     .clr         ( acmd_rst_b      ),
     .on          ( acmd_on_b       ),
     .astart      ( astart_b        ),
@@ -72,8 +76,10 @@ jt10_adpcmb_cnt u_cnt(
     .addr        ( addr            ),
     .nibble_sel  ( nibble_sel      ),
     // Flag control
+    .chon        ( chon            ),
     .clr_flag    ( clr_flag        ),
     .flag        ( flag            ),
+    .restart     ( restart         ),
     .adv         ( adv             )
 );
 
@@ -89,7 +95,8 @@ jt10_adpcmb u_decoder(
     .cen    ( cen            ),
     .adv    ( adv & cen55    ),
     .data   ( din            ),
-    .chon   ( acmd_on_b      ),
+    .chon   ( chon           ),
+    .clr    ( flag | restart ),
     .pcm    ( pcmdec         )
 );
 
@@ -98,7 +105,7 @@ jt10_adpcmb_interpol u_interpol(
     .rst_n  ( rst_n          ),
     .clk    ( clk            ),
     .cen    ( cen            ),
-    .cen55  ( cen55          ),
+    .cen55  ( cen55  && chon ),
     .adv    ( adv            ),
     .pcmdec ( pcmdec         ),
     .pcmout ( pcminter       )

--- a/hdl/adpcm/jt10_adpcmb.v
+++ b/hdl/adpcm/jt10_adpcmb.v
@@ -28,6 +28,7 @@ module jt10_adpcmb(
     input   [3:0]   data,
     input           chon,       // high if this channel is on
     input           adv,
+    input           clr,
     output signed [15:0] pcm
 );
 
@@ -38,8 +39,8 @@ reg [stepw-1:0] step1;
 reg [stepw+1:0] next_step3;
 assign pcm = x1[xw-1:xw-16];
 
-wire [xw-1:0] limpos = 32767;
-wire [xw-1:0] limneg = -32768;
+wire [xw-1:0] limpos = {1'b0, {xw-1{1'b1}}};
+wire [xw-1:0] limneg = {1'b1, {xw-1{1'b0}}};
 
 reg  [18:0] d2l;
 reg  [xw-1:0] d3,d4;
@@ -64,33 +65,43 @@ end
 // 666 kHz -> 18.5 kHz = 55.5/3 kHz
 
 reg [3:0] data2;
-reg sign_data;
+reg sign_data2, sign_data3, sign_data4, sign_data5;
 
 reg [3:0] adv2;
+reg need_clr;
+
+wire [3:0] data_use = clr || ~chon ? 4'd0 : data;
 
 always @( posedge clk or negedge rst_n )
     if( ! rst_n ) begin
         x1 <= 'd0; step1 <= 'd127;
         d2 <= 'd0; d3 <= 'd0; d4 <= 'd0;
-    end else if(cen) begin
-        adv2 <= {1'b0,adv2[3:1]};
-        // I
-        if( adv ) begin
-            d2        <= {data[2:0],1'b1};
-            sign_data <= data[3];
-            adv2[3] <= 1'b1;
-        end
-        // II multiply and obtain the offset
-        d3        <= { {xw-16{1'b0}}, d2l[18:3] }; // xw bits
-        next_step3<= step2l[22:6];
-        // III 2's complement of d3 if necessary
-        d4        <= sign_data ? ~d3+1 : d3;
-        // IV   Advance the waveform
-        next_x5   <= x1+d4;
-        // V: limit or reset outputs
-        if( chon ) begin // update values if needed
-            if( adv2[0] ) begin
-                    if( sign_data == x1[xw-1] && (x1[xw-1]!=next_x5[xw-1]) )
+        need_clr <= 0;
+    end else begin
+        if( clr )
+            need_clr <= 1'd1;
+        if(cen) begin
+            adv2 <= {1'b0,adv2[3:1]};
+            // I
+            if( adv ) begin
+                d2        <= {data_use[2:0],1'b1};
+                sign_data2 <= data_use[3];
+                adv2[3] <= 1'b1;
+            end
+            // II multiply and obtain the offset
+            d3        <= { {xw-16{1'b0}}, d2l[18:3] }; // xw bits
+            next_step3<= step2l[22:6];
+            sign_data3<=sign_data2;
+            // III 2's complement of d3 if necessary
+            d4        <= sign_data3 ? ~d3+1'd1 : d3;
+            sign_data4<=sign_data3;
+            // IV   Advance the waveform
+            next_x5   <= x1+d4;
+            sign_data5<=sign_data4;
+            // V: limit or reset outputs
+            if( chon ) begin // update values if needed
+                if( adv2[0] ) begin
+                    if( sign_data5 == x1[xw-1] && (x1[xw-1]!=next_x5[xw-1]) )
                         x1 <= x1[xw-1] ? limneg : limpos;
                     else
                         x1 <= next_x5;
@@ -102,11 +113,19 @@ always @( posedge clk or negedge rst_n )
                     else
                         step1 <= next_step3[14:0];
                 end
-        end else begin
-            x1      <= 'd0;
-            step1   <= 'd127;
+            end else begin
+                x1      <= 'd0;
+                step1   <= 'd127;
+            end
+            if( need_clr ) begin
+                x1      <= 'd0;
+                step1   <= 'd127;
+                next_step3   <= 'd127;
+                d2 <= 'd0; d3 <= 'd0; d4 <= 'd0;
+                next_x5 <= 'd0;
+                need_clr <= 1'd0;
+            end
         end
-    end
-
+	 end
 
 endmodule // jt10_adpcm

--- a/hdl/adpcm/jt10_adpcmb_cnt.v
+++ b/hdl/adpcm/jt10_adpcmb_cnt.v
@@ -30,6 +30,7 @@ module jt10_adpcmb_cnt(
     input   [15:0]      delta_n,
     input               clr,
     input               on,
+    input               acmd_up_b,
     // Address
     input       [15:0]  astart,
     input       [15:0]  aend,
@@ -37,8 +38,10 @@ module jt10_adpcmb_cnt(
     output  reg [23:0]  addr,
     output  reg         nibble_sel,
     // Flag
+    output  reg         chon,
     output  reg         flag,
     input               clr_flag,
+    output  reg         restart,
 
     output  reg         adv
 );
@@ -57,9 +60,11 @@ always @(posedge clk or negedge rst_n)
         end else begin
             if( on ) 
                 {adv, cnt} <= {1'b0, cnt} + {1'b0, delta_n };
-            else
+            else begin
+                cnt <= 'd0;
                 adv <= 1'b1; // let the rest of the signal chain advance
                     // when channel is off so all registers go to reset values
+            end
         end
     end
 
@@ -76,30 +81,33 @@ always @(posedge clk or negedge rst_n)
     end
 
 // Address
-reg last_on;
-
 always @(posedge clk or negedge rst_n)
     if(!rst_n) begin
         addr       <= 'd0;
         nibble_sel <= 'b0;
         set_flag   <= 'd0;
-    end else if(cen) begin
-        last_on <= on;
-
-        if( (on && !last_on) || clr ) begin
+        chon       <= 'b0;
+        restart    <= 'b0;
+    end else if( !on || clr ) begin
+        restart <= 'd0;
+        chon <= 'd0;
+    end else if( acmd_up_b && on ) begin
+        restart <= 'd1;
+    end else if( cen ) begin
+        if( restart && adv ) begin
             addr <= {astart,8'd0};
             nibble_sel <= 'b0;
-        end else if( on && adv ) begin
-            if( addr[23:8] < aend ) begin
+            restart <= 'd0;
+            chon <= 'd1;
+        end else if( chon && adv ) begin
+            if( { addr, nibble_sel } < { aend, 8'hFF, 1'b1 } ) begin
                 { addr, nibble_sel } <= { addr, nibble_sel } + 25'd1;
                 set_flag <= 'd0;
-            end
-            else begin
+            end else if(arepeat) begin
+                restart <= 'd1;
+            end else begin
                 set_flag <= 'd1;
-                if(arepeat) begin
-                    addr <= {astart,8'd0};
-                    nibble_sel <= 'b0;
-                end
+                chon <= 'd0;
             end
         end
     end // cen

--- a/hdl/adpcm/jt10_adpcmb_interpol.v
+++ b/hdl/adpcm/jt10_adpcmb_interpol.v
@@ -51,8 +51,8 @@ always @(posedge clk) if(cen55) begin
     if ( adv ) begin
         pre_dn  <= 'd1;
         deltan  <= pre_dn;
-    end else
-        pre_dn <= pre_dn + 1;
+    end else if ( pre_dn != 4'hF )
+        pre_dn <= pre_dn + 1'd1;
 end
 
 
@@ -66,7 +66,7 @@ always @(posedge clk) if(cen) begin
     end
     if( adv2[5] ) begin
         start_div <= 1'b1;
-        delta_x <= pre_dx[16] ? ~pre_dx[15:0]+1 : pre_dx[15:0];
+        delta_x <= pre_dx[16] ? ~pre_dx[15:0]+1'd1 : pre_dx[15:0];
         next_step_sign <= pre_dx[16];
     end        
 end
@@ -77,7 +77,7 @@ always @(posedge clk) if(cen55) begin
         step_sign <= next_step_sign;
         pcminter <= pcmlast;
     end
-    else pcminter <= step_sign ? pcminter - step : pcminter + step;
+    else pcminter <= ( (pcminter < pcmlast) == step_sign ) ? pcminter : step_sign ? pcminter - step : pcminter + step;
 end
 
 jt10_adpcm_div #(.dw(16)) u_div(

--- a/hdl/jt12_mmr.v
+++ b/hdl/jt12_mmr.v
@@ -70,6 +70,7 @@ module jt12_mmr(
     output  reg         acmd_on_b,  // Control - Process start, Key On
     output  reg         acmd_rep_b, // Control - Repeat
     output  reg         acmd_rst_b, // Control - Reset
+    output  reg         acmd_up_b,  // Control - New cmd received
     output  reg  [ 1:0] alr_b,      // Left / Right
     output  reg  [15:0] astart_b,   // Start address
     output  reg  [15:0] aend_b,     // End   address
@@ -362,7 +363,7 @@ always @(posedge clk) begin : memory_mapped_registers
                     if( !part && selected_register[7:4]==4'h1 ) begin
                         // YM2610 ADPCM-B support, A1=0, regs 1x
                         case(selected_register[3:0])
-                            4'd0: {acmd_on_b, acmd_rep_b,acmd_rst_b} <= {din[7],din[4],din[0]};
+                            4'd0: {acmd_up_b, acmd_on_b, acmd_rep_b,acmd_rst_b} <= {1'd1,din[7],din[4],din[0]};
                             4'd1: alr_b  <= din[7:6];
                             4'd2: astart_b [ 7:0] <= din;
                             4'd3: astart_b [15:8] <= din;
@@ -404,6 +405,7 @@ always @(posedge clk) begin : memory_mapped_registers
             pcm_wr   <= 1'b0;
             flag_ctl <= 'd0;
             up_aon   <= 1'b0;
+            acmd_up_b <= 1'b0;
         end
     end
 end

--- a/hdl/jt12_top.v
+++ b/hdl/jt12_top.v
@@ -211,7 +211,7 @@ if( use_adpcm==1 ) begin: gen_adpcm
         .acmd_on_b  ( acmd_on_b     ),  // Control - Process start, Key On
         .acmd_rep_b ( acmd_rep_b    ),  // Control - Repeat
         .acmd_rst_b ( acmd_rst_b    ),  // Control - Reset
-        .acmd_on_b  ( acmd_on_b     ),  // Control - New command received
+        .acmd_up_b  ( acmd_up_b     ),  // Control - New command received
         .alr_b      ( alr_b         ),  // Left / Right
         .astart_b   ( astart_b      ),  // Start address
         .aend_b     ( aend_b        ),  // End   address

--- a/hdl/jt12_top.v
+++ b/hdl/jt12_top.v
@@ -147,6 +147,7 @@ wire        up_aon;
 wire        acmd_on_b;     // Control - Process start, Key On
 wire        acmd_rep_b;    // Control - Repeat
 wire        acmd_rst_b;    // Control - Reset
+wire        acmd_up_b;     // Control - New cmd received
 wire [ 1:0] alr_b;         // Left / Right
 wire [15:0] astart_b;      // Start address
 wire [15:0] aend_b;        // End   address
@@ -210,6 +211,7 @@ if( use_adpcm==1 ) begin: gen_adpcm
         .acmd_on_b  ( acmd_on_b     ),  // Control - Process start, Key On
         .acmd_rep_b ( acmd_rep_b    ),  // Control - Repeat
         .acmd_rst_b ( acmd_rst_b    ),  // Control - Reset
+        .acmd_on_b  ( acmd_on_b     ),  // Control - New command received
         .alr_b      ( alr_b         ),  // Left / Right
         .astart_b   ( astart_b      ),  // Start address
         .aend_b     ( aend_b        ),  // End   address
@@ -330,6 +332,7 @@ jt12_mmr #(.use_ssg(use_ssg),.num_ch(num_ch),.use_pcm(use_pcm), .use_adpcm(use_a
     .acmd_on_b  ( acmd_on_b     ),  // Control - Process start, Key On
     .acmd_rep_b ( acmd_rep_b    ),  // Control - Repeat
     .acmd_rst_b ( acmd_rst_b    ),  // Control - Reset
+    .acmd_up_b  ( acmd_up_b     ),  // Control - New command received
     .alr_b      ( alr_b         ),  // Left / Right
     .astart_b   ( astart_b      ),  // Start address
     .aend_b     ( aend_b        ),  // End   address


### PR DESCRIPTION
These changes do several things:
- If a new acmd_on_b comes in with a start, the previous sample in progress should start over. If this is isn't tracked, if ADPCMB is already playing a sample, this will be ignored and continue playing, rather than starting over.
- If a sample completes, it needs to reset all the variables that the entire chain uses.  Failure to do this causes volume spikes (see for example KoF95, and Magical Drop 2).
- When a sample completes, everything needs to stop playing throughout the chain.  (see for example Crossed Swords 1 and 2 and Shock Troopers).
- The first sample was not being played in many cases (see Magical Drop 2).
- I don't think the done flag should be propogated up to the main interface when repeating a sample.
- I believe the end sample should be {end_address, 8'hFF}.  This change has been made.
I'm not certain on these changes.  If you have questions or comments please post.  Whatever final changes are used, the above mentioned games, in addition to Strikers 1945 and Ninja Combat should be tested, as they all had problems before these changes.