### PR TITLE
Current/Enable Channel Timing change needed for MiSTer

### DIFF
--- a/hdl/adpcm/jt10_adpcm_acc.v
+++ b/hdl/adpcm/jt10_adpcm_acc.v
@@ -62,7 +62,7 @@ always @(posedge clk or negedge rst_n)
         last <= 18'd0;
     end else if(cen) begin
         if( match )
-            acc <= en_ch[0] ? pcm_in_long : ( pcm_in_long + acc );
+            acc <= cur_ch[0] ? pcm_in_long : ( pcm_in_long + acc );
         if( adv ) begin
             // step = diff * (1/4+1/16+1/64+1/128)
             step <= { {2{step_full[22]}}, step_full[22:7] }; // >>>7;

--- a/hdl/adpcm/jt10_adpcm_cnt.v
+++ b/hdl/adpcm/jt10_adpcm_cnt.v
@@ -70,7 +70,8 @@ assign roe_n    = roe_n1;
 assign clr      = clr1;
 assign decon    = decon1;
 
-wire active5 = { cur_ch[1:0], cur_ch[5:2] } == en_ch;
+// Two cycles early:  0            0             1            1             2            2             3            3             4            4             5            5
+wire active5 = (en_ch[1] && cur_ch[4]) || (en_ch[2] && cur_ch[5]) || (en_ch[2] && cur_ch[0]) || (en_ch[3] && cur_ch[1]) || (en_ch[4] && cur_ch[2]) || (en_ch[5] && cur_ch[3]);//{ cur_ch[3:0], cur_ch[5:4] } == en_ch;
 wire sumup5  = on5 && !done5 && active5;
 reg  sumup6;
 

--- a/hdl/adpcm/jt10_adpcm_drvA.v
+++ b/hdl/adpcm/jt10_adpcm_drvA.v
@@ -89,7 +89,7 @@ end
 reg match; // high when cur_ch==en_ch, but calculated one clock cycle ahead
     // so it can be latched
 wire [5:0] cur_next = { cur_ch[4:0], cur_ch[5] };
-wire [5:0]  en_next = {en_ch[4:0], en_ch[5] };
+wire [5:0]  en_next = {  en_ch[0],  en_ch[5:1] };
 
 always @(posedge clk or negedge rst_n) 
     if( !rst_n ) begin

--- a/hdl/adpcm/jt10_adpcm_gain.v
+++ b/hdl/adpcm/jt10_adpcm_gain.v
@@ -50,7 +50,7 @@ always @(*)
         default: up_ch_dec = 6'd0;
     endcase
 
-wire [5:0] en_ch2 = { en_ch[4:0], en_ch[5] }; // shift the bits to fit in the pipeline slot correctly
+//wire [5:0] en_ch2 = { en_ch[4:0], en_ch[5] }; // shift the bits to fit in the pipeline slot correctly
 
 reg  [6:0] db5;
 always @(*)


### PR DESCRIPTION
This change may not actually be a change to match hardware behavior, but is needed to work with MiSTer.  If cur_ch and en_ch are shifted the same direction {(0,0), (1,1), (2,2), (3,3), (4,4), (5,5)}, then the time between 0,0 and 1,1 is 7 cycles, and the time between (5,5) and (0,0) is 1 cycle (7 * 5 + 1 * 1 = 36 total cycles).  MiSTer does not like the 1 cycle difference when reading the sample ROMs.  This change inverts the en_ch variable so the timing is instead (5 * 5 + 11 * 1 = 36 total cycles).  This gives a minimum time between samples of 5 cycles.  I tried just moving the en_ch instead of inverting the shift order, and that just moved which channel had the 1 cycle minimum (and which channel malfunctioned because of bad sample ROM reading).  If this doesn't match real hardware, maybe a parameter (accurate vs slow timing requirement) could be added for implementations like MiSTer that require larger minimum read spacing?