### PR TITLE
Don't allow div_setting change on YM2610/2612

### DIFF
--- a/hdl/jt03.v
+++ b/hdl/jt03.v
@@ -52,7 +52,7 @@ module jt03(
 );
 
 jt12_top #(
-    .use_lfo(0),.use_ssg(1), .num_ch(3), .use_pcm(0), .use_adpcm(0) )
+    .use_lfo(0),.use_ssg(1), .num_ch(3), .use_pcm(0), .use_adpcm(0), mask_div(0) )
 u_jt12(
     .rst            ( rst          ),        // rst should be at least 6 clk&cen cycles long
     .clk            ( clk          ),        // CPU clock

--- a/hdl/jt12_mmr.v
+++ b/hdl/jt12_mmr.v
@@ -126,7 +126,7 @@ module jt12_mmr(
     input   [7:0]   debug_bus
 );
 
-parameter use_ssg=0, num_ch=6, use_pcm=1, use_adpcm=0;
+parameter use_ssg=0, num_ch=6, use_pcm=1, use_adpcm=0, mask_div=1;
 
 jt12_div #(.use_ssg(use_ssg)) u_div (
     .rst            ( rst             ),
@@ -264,6 +264,7 @@ always @(posedge clk) begin : memory_mapped_registers
             if( !addr[0] ) begin
                 selected_register <= din;  
                 part <= addr[1];        
+                if (!mask_div)
                 case(din)
                     // clock divider: should work only for ym2203
                     // and ym2608.

--- a/hdl/jt12_top.v
+++ b/hdl/jt12_top.v
@@ -72,6 +72,7 @@ module jt12_top (
 parameter use_lfo=1, use_ssg=0, num_ch=6, use_pcm=1;
 parameter use_adpcm=0;
 parameter JT49_DIV=2;
+parameter mask_div=1;
 
 wire flag_A, flag_B, busy;
 
@@ -289,7 +290,7 @@ jt12_dout #(.use_ssg(use_ssg),.use_adpcm(use_adpcm)) u_dout(
 
 
 /* verilator tracing_on */
-jt12_mmr #(.use_ssg(use_ssg),.num_ch(num_ch),.use_pcm(use_pcm), .use_adpcm(use_adpcm))
+jt12_mmr #(.use_ssg(use_ssg),.num_ch(num_ch),.use_pcm(use_pcm), .use_adpcm(use_adpcm), .mask_div(mask_div))
     u_mmr(
     .rst        ( rst       ),
     .clk        ( clk       ),


### PR DESCRIPTION
This one fixes #62 as it disallows to change the clock divider setting on YM2610/12 by software.