### PR TITLE
Add ladder effect

### DIFF
--- a/hdl/jt03.v
+++ b/hdl/jt03.v
@@ -52,7 +52,7 @@ module jt03(
 );
 
 jt12_top #(
-    .use_lfo(0),.use_ssg(1), .num_ch(3), .use_pcm(0), .use_adpcm(0) )
+    .use_lfo(0),.use_ssg(1), .num_ch(3), .use_pcm(0), .use_adpcm(0), .mask_div(0) )
 u_jt12(
     .rst            ( rst          ),        // rst should be at least 6 clk&cen cycles long
     .clk            ( clk          ),        // CPU clock

--- a/hdl/jt12.v
+++ b/hdl/jt12.v
@@ -35,6 +35,7 @@ module jt12 (
     output          irq_n,
     // configuration
     input           en_hifi_pcm,
+    input           ladder,
     // combined output
     output  signed  [15:0]  snd_right,
     output  signed  [15:0]  snd_left,
@@ -55,6 +56,7 @@ jt12_top u_jt12(
     .irq_n  ( irq_n ),
     // configuration
     .en_hifi_pcm    ( en_hifi_pcm ),
+    .ladder         ( ladder      ),
     // Unused ADPCM pins
     .adpcma_addr    (      ), // real hardware has 10 pins multiplexed through RMPX pin
     .adpcma_bank    (      ),

--- a/hdl/jt12_acc.v
+++ b/hdl/jt12_acc.v
@@ -74,19 +74,42 @@ always @(posedge clk) if(clk_en)
 
 wire use_pcm = ch6op && pcm_en;
 wire sum_or_pcm = sum_en | use_pcm;
+// wire left_en = rl[1];
+// wire right_en= rl[0];
 wire signed [8:0] pcm_data = pcm_sum ? pcm : 9'd0;
+// wire [8:0] acc_input =  use_pcm ? pcm_data : op_result;
 wire signed [8:0] acc_input = ~channel_en ? 9'd0 : (use_pcm ? pcm_data : op_result);
 
 // Continuous output
-wire signed   [8:0]  acc_out;
+// wire signed   [11:0]  pre_left, pre_right;
+wire signed [8:0] acc_out;
+// jt12_single_acc #(.win(9),.wout(12)) u_left(
 jt12_single_acc #(.win(9),.wout(9)) u_acc(
     .clk        ( clk            ),
     .clk_en     ( clk_en         ),
     .op_result  ( acc_input      ),
+    // .sum_en     ( sum_or_pcm & left_en ),
     .sum_en     ( sum_or_pcm     ),
     .zero       ( zero           ),
+    // .snd        ( pre_left       )
     .snd        ( acc_out        )
 );
+
+// jt12_single_acc #(.win(9),.wout(12)) u_right(
+//     .clk        ( clk            ),
+//     .clk_en     ( clk_en         ),
+//     .op_result  ( acc_input      ),
+//     .sum_en     ( sum_or_pcm & right_en ),
+//     .zero       ( zero           ),
+//     .snd        ( pre_right      )
+// );
+
+// Output can be amplied by 8/6=1.33 to use full range
+// an easy alternative is to add 1/4th and get 1.25 amplification
+// always @(posedge clk) if(clk_en) begin
+//     left  <= pre_left  + { {2{pre_left [11]}}, pre_left [11:2] };
+//     right <= pre_right + { {2{pre_right[11]}}, pre_right[11:2] };
+// end
 
 wire signed [15:0] acc_expand = {{7{acc_out[8]}}, acc_out};
 
@@ -95,8 +118,6 @@ reg [1:0] rl_latch, rl_old;
 wire signed [4:0] ladder_left = ~ladder ? 5'd0 : (acc_expand >= 0 ? 5'd7 : (rl_old[1] ? 5'd0 : -5'd6));
 wire signed [4:0] ladder_right = ~ladder ? 5'd0 : (acc_expand >= 0 ? 5'd7 : (rl_old[0] ? 5'd0 : -5'd6));
 
-// Output can be amplied by 8/6=1.33 to use full range
-// an easy alternative is to add 1/4th and get 1.25 amplification
 always @(posedge clk) if(clk_en) begin
     if (channel_en)
         rl_latch <= rl;

--- a/hdl/jt12_acc.v
+++ b/hdl/jt12_acc.v
@@ -37,6 +37,8 @@ module jt12_acc(
     input               rst,
     input               clk,
     input               clk_en /* synthesis direct_enable */,
+    input               ladder,
+    input               channel_en,
     input signed [8:0]  op_result,
     input        [ 1:0] rl,
     input               zero,
@@ -49,8 +51,8 @@ module jt12_acc(
     input               pcm_en, // only enabled for channel 6
     input   signed [8:0] pcm,
     // combined output
-    output reg signed   [11:0]  left,
-    output reg signed   [11:0]  right
+    output reg signed   [15:0]  left,
+    output reg signed   [15:0]  right
 );
 
 reg sum_en;
@@ -72,36 +74,37 @@ always @(posedge clk) if(clk_en)
 
 wire use_pcm = ch6op && pcm_en;
 wire sum_or_pcm = sum_en | use_pcm;
-wire left_en = rl[1];
-wire right_en= rl[0];
 wire signed [8:0] pcm_data = pcm_sum ? pcm : 9'd0;
-wire [8:0] acc_input =  use_pcm ? pcm_data : op_result;
+wire signed [8:0] acc_input = ~channel_en ? 9'd0 : (use_pcm ? pcm_data : op_result);
 
 // Continuous output
-wire signed   [11:0]  pre_left, pre_right;
-jt12_single_acc #(.win(9),.wout(12)) u_left(
+wire signed   [8:0]  acc_out;
+jt12_single_acc #(.win(9),.wout(9)) u_acc(
     .clk        ( clk            ),
     .clk_en     ( clk_en         ),
     .op_result  ( acc_input      ),
-    .sum_en     ( sum_or_pcm & left_en ),
+    .sum_en     ( sum_or_pcm     ),
     .zero       ( zero           ),
-    .snd        ( pre_left       )
+    .snd        ( acc_out        )
 );
 
-jt12_single_acc #(.win(9),.wout(12)) u_right(
-    .clk        ( clk            ),
-    .clk_en     ( clk_en         ),
-    .op_result  ( acc_input      ),
-    .sum_en     ( sum_or_pcm & right_en ),
-    .zero       ( zero           ),
-    .snd        ( pre_right      )
-);
+wire signed [15:0] acc_expand = {{7{acc_out[8]}}, acc_out};
+
+reg [1:0] rl_latch, rl_old;
+
+wire signed [4:0] ladder_left = ~ladder ? 5'd0 : (acc_expand >= 0 ? 5'd7 : (rl_old[1] ? 5'd0 : -5'd6));
+wire signed [4:0] ladder_right = ~ladder ? 5'd0 : (acc_expand >= 0 ? 5'd7 : (rl_old[0] ? 5'd0 : -5'd6));
 
 // Output can be amplied by 8/6=1.33 to use full range
 // an easy alternative is to add 1/4th and get 1.25 amplification
 always @(posedge clk) if(clk_en) begin
-    left  <= pre_left  + { {2{pre_left [11]}}, pre_left [11:2] };
-    right <= pre_right + { {2{pre_right[11]}}, pre_right[11:2] };
+    if (channel_en)
+        rl_latch <= rl;
+    if (zero)
+        rl_old <= rl_latch;
+
+    left  <= rl_old[1] ? acc_expand + ladder_left : ladder_left;
+    right <= rl_old[0] ? acc_expand + ladder_right : ladder_right;
 end
 
 endmodule

--- a/hdl/jt12_top.v
+++ b/hdl/jt12_top.v
@@ -32,12 +32,12 @@ module jt12_top (
     input   [1:0]   addr,
     input           cs_n,
     input           wr_n,
+    input           ladder,
 
     output  [7:0]   dout,
     output          irq_n,
     // Configuration
     input           en_hifi_pcm,  // high to enable PCM interpolation on YM2612 mode
-    input           ladder,       // ym2612 ladder effect
     // ADPCM pins
     output  [19:0]  adpcma_addr,  // real hardware has 10 pins multiplexed through RMPX pin
     output  [ 3:0]  adpcma_bank,
@@ -73,6 +73,7 @@ module jt12_top (
 parameter use_lfo=1, use_ssg=0, num_ch=6, use_pcm=1;
 parameter use_adpcm=0;
 parameter JT49_DIV=2;
+parameter mask_div=1;
 
 wire flag_A, flag_B, busy;
 
@@ -290,7 +291,7 @@ jt12_dout #(.use_ssg(use_ssg),.use_adpcm(use_adpcm)) u_dout(
 
 
 /* verilator tracing_on */
-jt12_mmr #(.use_ssg(use_ssg),.num_ch(num_ch),.use_pcm(use_pcm), .use_adpcm(use_adpcm))
+jt12_mmr #(.use_ssg(use_ssg),.num_ch(num_ch),.use_pcm(use_pcm), .use_adpcm(use_adpcm), .mask_div(mask_div))
     u_mmr(
     .rst        ( rst       ),
     .clk        ( clk       ),
@@ -586,8 +587,11 @@ wire signed [15:0] accum_l[7];
 
 assign fm_snd_left = accum_l[0] + accum_l[1] + accum_l[2] + accum_l[4] + accum_l[5] + accum_l[6];
 assign fm_snd_right = accum_r[0] + accum_r[1] + accum_r[2] + accum_r[4] + accum_r[5] + accum_r[6];
+
 generate
     if( use_pcm==1 ) begin: gen_pcm_acc // YM2612 accumulator
+        // assign fm_snd_right[3:0] = 4'd0;
+        // assign fm_snd_left [3:0] = 4'd0;
         assign snd_sample        = zero;
         reg signed [8:0] pcm2;
 
@@ -652,8 +656,10 @@ generate
             .pcm        ( pcm2      ),
             .alg        ( alg_I     ),
             // combined output
-            .left       ( accum_l[i]  ),
-            .right      ( accum_r[i]  )
+            // .left       ( fm_snd_left [15:4]  ),
+            // .right      ( fm_snd_right[15:4]  )
+            .left       ( accum_l[i]),
+            .right      ( accum_r[i])
         );
         end
     end


### PR DESCRIPTION
This adds the ladder effect the same way @Kitrinx did in the Genesis MiSTer core. Hopefully this addresses this issue --> https://github.com/jotego/jt12/issues/63

In the case of the Genesis MiSTer core, the correct way to hook up the sound to toggle this is like so:

* A toggle in the configuration string:
![image](https://user-images.githubusercontent.com/16388068/167217679-609a196f-d4d3-49cb-a218-33d05e4c727a.png)
* Instantiating the ports into the core's top-level module and (in this case) adjusting the audio balance to match MDFourier:
![image](https://user-images.githubusercontent.com/16388068/167217805-48da1663-a913-4483-a732-7311c143e178.png)

Submitting PR in hopes of resolving the issues cited here --> https://github.com/MiSTer-devel/Genesis_MiSTer/issues/209 as my PR (https://github.com/MiSTer-devel/Genesis_MiSTer/pull/210) was rejected because the upstream should be updated instead.