### PR TITLE
Change clr_flag to not mute adpcm channels.

### DIFF
--- a/hdl/adpcm/jt10_adpcm_drvB.v
+++ b/hdl/adpcm/jt10_adpcm_drvB.v
@@ -47,7 +47,7 @@ module jt10_adpcm_drvB(
 
 wire nibble_sel;
 wire adv;           // advance to next reading
-wire restart;
+wire clr_dec;
 wire chon;
 
 // `ifdef SIMULATION
@@ -79,7 +79,7 @@ jt10_adpcmb_cnt u_cnt(
     .chon        ( chon            ),
     .clr_flag    ( clr_flag        ),
     .flag        ( flag            ),
-    .restart     ( restart         ),
+    .clr_dec     ( clr_dec         ),
     .adv         ( adv             )
 );
 
@@ -96,7 +96,7 @@ jt10_adpcmb u_decoder(
     .adv    ( adv & cen55    ),
     .data   ( din            ),
     .chon   ( chon           ),
-    .clr    ( flag | restart ),
+    .clr    ( clr_dec        ),
     .pcm    ( pcmdec         )
 );
 

--- a/hdl/adpcm/jt10_adpcmb_cnt.v
+++ b/hdl/adpcm/jt10_adpcmb_cnt.v
@@ -41,7 +41,7 @@ module jt10_adpcmb_cnt(
     output  reg         chon,
     output  reg         flag,
     input               clr_flag,
-    output  reg         restart,
+    output  reg         clr_dec,
 
     output  reg         adv
 );
@@ -69,6 +69,7 @@ always @(posedge clk or negedge rst_n)
     end
 
 reg set_flag, last_set;
+reg restart;
 
 always @(posedge clk or negedge rst_n)
     if(!rst_n) begin
@@ -88,9 +89,11 @@ always @(posedge clk or negedge rst_n)
         set_flag   <= 'd0;
         chon       <= 'b0;
         restart    <= 'b0;
+		  clr_dec    <= 'b1;
     end else if( !on || clr ) begin
         restart <= 'd0;
         chon <= 'd0;
+		  clr_dec <= 'd1;
     end else if( acmd_up_b && on ) begin
         restart <= 'd1;
     end else if( cen ) begin
@@ -99,15 +102,18 @@ always @(posedge clk or negedge rst_n)
             nibble_sel <= 'b0;
             restart <= 'd0;
             chon <= 'd1;
+            clr_dec <= 'd0;
         end else if( chon && adv ) begin
             if( { addr, nibble_sel } != { aend, 8'hFF, 1'b1 } ) begin
                 { addr, nibble_sel } <= { addr, nibble_sel } + 25'd1;
                 set_flag <= 'd0;
             end else if(arepeat) begin
                 restart <= 'd1;
+                clr_dec <= 'd1;
             end else begin
                 set_flag <= 'd1;
                 chon <= 'd0;
+                clr_dec <= 'd1;
             end
         end
     end // cen

--- a/hdl/jt12_top.v
+++ b/hdl/jt12_top.v
@@ -72,6 +72,7 @@ module jt12_top (
 parameter use_lfo=1, use_ssg=0, num_ch=6, use_pcm=1;
 parameter use_adpcm=0;
 parameter JT49_DIV=2;
+parameter mask_div=1;
 
 wire flag_A, flag_B, busy;
 

--- a/hdl/jt12_top.v
+++ b/hdl/jt12_top.v
@@ -27,7 +27,7 @@ http://gendev.spritesmind.net/forum/viewtopic.php?t=386&postdays=0&postorder=asc
 module jt12_top (
     input           rst,        // rst should be at least 6 clk&cen cycles long
     input           clk,        // CPU clock
-    input           cen,        // optional clock enable, it not needed leave as 1'b1
+    (* direct_enable *) input cen,        // optional clock enable, if not needed leave as 1'b1
     input   [7:0]   din,
     input   [1:0]   addr,
     input           cs_n,
@@ -45,6 +45,9 @@ module jt12_top (
     output  [23:0]  adpcmb_addr,  // real hardware has 12 pins multiplexed through PMPX pin
     input   [ 7:0]  adpcmb_data,
     output          adpcmb_roe_n, // ADPCM-B ROM output enable
+    // I/O pins used by YM2203 embedded YM2149 chip
+    input      [7:0] IOA_in,
+    input      [7:0] IOB_in,
     // Separated output
     output          [ 7:0] psg_A,
     output          [ 7:0] psg_B,
@@ -60,14 +63,14 @@ module jt12_top (
     output  signed  [15:0] snd_right, // FM+PSG
     output  signed  [15:0] snd_left,  // FM+PSG
     output                 snd_sample,
-    input   [3:0]          snd_enable,
-    input   [5:0]          ch_enable
+    input           [ 7:0] debug_bus,
+    output          [ 7:0] debug_view
 );
 
 // parameters to select the features for each chip type
 // defaults to YM2612
 parameter use_lfo=1, use_ssg=0, num_ch=6, use_pcm=1;
-parameter use_adpcm=0, use_clkdiv=1;
+parameter use_adpcm=0;
 parameter JT49_DIV=2;
 
 wire flag_A, flag_B, busy;
@@ -160,19 +163,11 @@ wire [ 5:0] adpcma_flags;  // ADPMC-A read over flags
 wire        adpcmb_flag;
 wire [ 6:0] flag_ctl;
 wire [ 6:0] flag_mask;
-
+wire [ 1:0] div_setting;
 
 wire clk_en_2, clk_en_666, clk_en_111, clk_en_55;
-wire  signed  [15:0] adpcmAt_l;
-wire  signed  [15:0] adpcmAt_r;
-wire  signed  [15:0] adpcmBt_l;
-wire  signed  [15:0] adpcmBt_r;
-assign adpcmA_l = snd_enable[1] ? adpcmAt_l : 16'd0;
-assign adpcmA_r = snd_enable[1] ? adpcmAt_r : 16'd0;
-assign adpcmB_l = snd_enable[2] ? adpcmBt_l : 16'd0;
-assign adpcmB_r = snd_enable[2] ? adpcmBt_r : 16'd0;
-wire  [13:0] op_result_hdt;
-assign op_result_hd = snd_enable[0] ? op_result_hdt : 14'd0;
+
+assign debug_view = { 4'd0, flag_B, flag_A, div_setting };
 
 generate
 if( use_adpcm==1 ) begin: gen_adpcm
@@ -211,9 +206,8 @@ if( use_adpcm==1 ) begin: gen_adpcm
         .flags      ( adpcma_flags  ),
         .clr_flags  ( flag_ctl[5:0] ),
 
-        .pcm55_l    ( adpcmAt_l      ),
-        .pcm55_r    ( adpcmAt_r      ),
-        .ch_enable  ( ch_enable      )
+        .pcm55_l    ( adpcmA_l      ),
+        .pcm55_r    ( adpcmA_r      )
     );
     /* verilator tracing_on */
     jt10_adpcm_drvB u_adpcm_b(
@@ -221,12 +215,12 @@ if( use_adpcm==1 ) begin: gen_adpcm
         .clk        ( clk           ),
         .cen        ( cen           ),
         .cen55      ( clk_en_55     ),
-        
+
         // Control
         .acmd_on_b  ( acmd_on_b     ),  // Control - Process start, Key On
         .acmd_rep_b ( acmd_rep_b    ),  // Control - Repeat
         .acmd_rst_b ( acmd_rst_b    ),  // Control - Reset
-		  .acmd_up_b  ( acmd_up_b     ),  // Control - New command received
+        .acmd_up_b  ( acmd_up_b     ),  // Control - New command received
         .alr_b      ( alr_b         ),  // Left / Right
         .astart_b   ( astart_b      ),  // Start address
         .aend_b     ( aend_b        ),  // End   address
@@ -240,12 +234,12 @@ if( use_adpcm==1 ) begin: gen_adpcm
         .data       ( adpcmb_data   ),
         .roe_n      ( adpcmb_roe_n  ),
 
-        .pcm55_l    ( adpcmBt_l      ),
-        .pcm55_r    ( adpcmBt_r      )
+        .pcm55_l    ( adpcmB_l      ),
+        .pcm55_r    ( adpcmB_r      )
     );
 
     /* verilator tracing_on */
-    assign snd_sample   = zero;        
+    assign snd_sample   = zero;
     jt10_acc u_acc(
         .clk        ( clk           ),
         .clk_en     ( clk_en        ),
@@ -280,7 +274,7 @@ end else begin : gen_adpcm_no
 end
 endgenerate
 
-/* verilator tracing_off */
+/* verilator tracing_on */
 jt12_dout #(.use_ssg(use_ssg),.use_adpcm(use_adpcm)) u_dout(
 //    .rst_n          ( rst_n         ),
     .clk            ( clk           ),        // CPU clock
@@ -295,8 +289,8 @@ jt12_dout #(.use_ssg(use_ssg),.use_adpcm(use_adpcm)) u_dout(
 );
 
 
-/* verilator tracing_off */
-jt12_mmr #(.use_ssg(use_ssg),.num_ch(num_ch),.use_pcm(use_pcm), .use_adpcm(use_adpcm), .use_clkdiv(use_clkdiv))
+/* verilator tracing_on */
+jt12_mmr #(.use_ssg(use_ssg),.num_ch(num_ch),.use_pcm(use_pcm), .use_adpcm(use_adpcm), .mask_div(mask_div))
     u_mmr(
     .rst        ( rst       ),
     .clk        ( clk       ),
@@ -352,7 +346,7 @@ jt12_mmr #(.use_ssg(use_ssg),.num_ch(num_ch),.use_pcm(use_pcm), .use_adpcm(use_a
     .astart_b   ( astart_b      ),  // Start address
     .aend_b     ( aend_b        ),  // End   address
     .adeltan_b  ( adeltan_b     ),  // Delta-N
-    .aeg_b      ( aeg_b         ),  // Envelope Generator Control    
+    .aeg_b      ( aeg_b         ),  // Envelope Generator Control
     .flag_ctl   ( flag_ctl      ),
     .flag_mask  ( flag_mask     ),
     // Operator
@@ -399,17 +393,20 @@ jt12_mmr #(.use_ssg(use_ssg),.num_ch(num_ch),.use_pcm(use_pcm), .use_adpcm(use_a
     // PSG interace
     .psg_addr   ( psg_addr  ),
     .psg_data   ( psg_data  ),
-    .psg_wr_n   ( psg_wr_n  )
+    .psg_wr_n   ( psg_wr_n  ),
+    .debug_bus  ( debug_bus ),
+    .div_setting(div_setting)
 );
 
-/* verilator tracing_off */
-// YM2203 seems to use a fixed cen/3 clock for the timers, regardless 
+/* verilator tracing_on */
+// YM2203 seems to use a fixed cen/3 clock for the timers, regardless
 // of the prescaler setting
-wire timer_cen = num_ch==3 ? clk_en_2 : ( fast_timers ? cen : clk_en);
-jt12_timers u_timers(
+wire timer_cen = fast_timers ? cen : clk_en;
+jt12_timers #(.num_ch(num_ch)) u_timers (
     .clk        ( clk           ),
     .clk_en     ( timer_cen     ),
     .rst        ( rst           ),
+    .zero       ( zero          ),
     .value_A    ( value_A       ),
     .value_B    ( value_B       ),
     .load_A     ( load_A        ),
@@ -451,7 +448,7 @@ endgenerate
 `ifndef NOSSG
 generate
     if( use_ssg==1 ) begin : gen_ssg
-        jt49 #(.COMP(2'b01), .CLKDIV(JT49_DIV)) 
+        jt49 #(.COMP(2'b01), .CLKDIV(JT49_DIV))
             u_psg( // note that input ports are not multiplexed
             .rst_n      ( ~rst      ),
             .clk        ( clk       ),    // signal on positive edge
@@ -467,13 +464,14 @@ generate
             .dout       ( psg_dout  ),
             .sel        ( 1'b1      ),  // half clock speed
             // Unused:
-            .IOA_out    (),
-            .IOB_out    (),
-            .IOA_in     (8'd0),
-            .IOB_in     (8'd0)
+            .IOA_out    (           ),
+            .IOB_out    (           ),
+            .IOA_in     ( IOA_in    ),
+            .IOB_in     ( IOB_in    ),
+            .sample     (           )
         );
-        assign snd_left  = snd_enable[3] ? fm_snd_left  + { 1'b0, psg_snd[9:0],5'd0} : fm_snd_left;
-        assign snd_right = snd_enable[3] ? fm_snd_right + { 1'b0, psg_snd[9:0],5'd0} : fm_snd_right;
+        assign snd_left  = fm_snd_left  + { 1'b0, psg_snd[9:0],5'd0};
+        assign snd_right = fm_snd_right + { 1'b0, psg_snd[9:0],5'd0};
     end else begin : gen_nossg
         assign psg_snd  = 10'd0;
         assign snd_left = fm_snd_left;
@@ -494,7 +492,7 @@ endgenerate
 wire    [ 8:0]  op_result;
 wire    [13:0]  op_result_hd;
 `ifndef NOFM
-/* verilator tracing_off */
+/* verilator tracing_on */
 jt12_pg #(.num_ch(num_ch)) u_pg(
     .rst        ( rst           ),
     .clk        ( clk           ),
@@ -575,9 +573,9 @@ jt12_op #(.num_ch(num_ch)) u_op(
     .yuse_prev2     ( yuse_prev2    ),
     .zero           ( zero          ),
     .op_result      ( op_result     ),
-    .full_result    ( op_result_hdt  )
+    .full_result    ( op_result_hd  )
 );
-`else 
+`else
 assign op_result    = 'd0;
 assign op_result_hd = 'd0;
 `endif
@@ -617,7 +615,7 @@ generate
         wire signed [10:0] pcm_full;
         always @(*)
             pcm2 = en_hifi_pcm ? pcm_full[9:1] : pcm;
-            
+
         jt12_pcm_interpol #(.dw(11), .stepw(5)) u_pcm (
             .rst_n ( rst_pcm_n      ),
             .clk   ( clk            ),

--- a/hdl/jt12_top.v
+++ b/hdl/jt12_top.v
@@ -27,7 +27,7 @@ http://gendev.spritesmind.net/forum/viewtopic.php?t=386&postdays=0&postorder=asc
 module jt12_top (
     input           rst,        // rst should be at least 6 clk&cen cycles long
     input           clk,        // CPU clock
-    (* direct_enable *) input cen,        // optional clock enable, if not needed leave as 1'b1
+    input           cen,        // optional clock enable, it not needed leave as 1'b1
     input   [7:0]   din,
     input   [1:0]   addr,
     input           cs_n,
@@ -45,9 +45,6 @@ module jt12_top (
     output  [23:0]  adpcmb_addr,  // real hardware has 12 pins multiplexed through PMPX pin
     input   [ 7:0]  adpcmb_data,
     output          adpcmb_roe_n, // ADPCM-B ROM output enable
-    // I/O pins used by YM2203 embedded YM2149 chip
-    input      [7:0] IOA_in,
-    input      [7:0] IOB_in,
     // Separated output
     output          [ 7:0] psg_A,
     output          [ 7:0] psg_B,
@@ -63,16 +60,15 @@ module jt12_top (
     output  signed  [15:0] snd_right, // FM+PSG
     output  signed  [15:0] snd_left,  // FM+PSG
     output                 snd_sample,
-    input           [ 7:0] debug_bus,
-    output          [ 7:0] debug_view
+    input   [3:0]          snd_enable,
+    input   [5:0]          ch_enable
 );
 
 // parameters to select the features for each chip type
 // defaults to YM2612
 parameter use_lfo=1, use_ssg=0, num_ch=6, use_pcm=1;
-parameter use_adpcm=0;
+parameter use_adpcm=0, use_clkdiv=1;
 parameter JT49_DIV=2;
-parameter mask_div=1;
 
 wire flag_A, flag_B, busy;
 
@@ -163,11 +159,20 @@ wire [ 7:0] aeg_b;         // Envelope Generator Control
 wire [ 5:0] adpcma_flags;  // ADPMC-A read over flags
 wire        adpcmb_flag;
 wire [ 6:0] flag_ctl;
-wire [ 1:0] div_setting;
+wire [ 6:0] flag_mask;
+
 
 wire clk_en_2, clk_en_666, clk_en_111, clk_en_55;
-
-assign debug_view = { 4'd0, flag_B, flag_A, div_setting };
+wire  signed  [15:0] adpcmAt_l;
+wire  signed  [15:0] adpcmAt_r;
+wire  signed  [15:0] adpcmBt_l;
+wire  signed  [15:0] adpcmBt_r;
+assign adpcmA_l = snd_enable[1] ? adpcmAt_l : 16'd0;
+assign adpcmA_r = snd_enable[1] ? adpcmAt_r : 16'd0;
+assign adpcmB_l = snd_enable[2] ? adpcmBt_l : 16'd0;
+assign adpcmB_r = snd_enable[2] ? adpcmBt_r : 16'd0;
+wire  [13:0] op_result_hdt;
+assign op_result_hd = snd_enable[0] ? op_result_hdt : 14'd0;
 
 generate
 if( use_adpcm==1 ) begin: gen_adpcm
@@ -206,8 +211,9 @@ if( use_adpcm==1 ) begin: gen_adpcm
         .flags      ( adpcma_flags  ),
         .clr_flags  ( flag_ctl[5:0] ),
 
-        .pcm55_l    ( adpcmA_l      ),
-        .pcm55_r    ( adpcmA_r      )
+        .pcm55_l    ( adpcmAt_l      ),
+        .pcm55_r    ( adpcmAt_r      ),
+        .ch_enable  ( ch_enable      )
     );
     /* verilator tracing_on */
     jt10_adpcm_drvB u_adpcm_b(
@@ -215,12 +221,12 @@ if( use_adpcm==1 ) begin: gen_adpcm
         .clk        ( clk           ),
         .cen        ( cen           ),
         .cen55      ( clk_en_55     ),
-
+        
         // Control
         .acmd_on_b  ( acmd_on_b     ),  // Control - Process start, Key On
         .acmd_rep_b ( acmd_rep_b    ),  // Control - Repeat
         .acmd_rst_b ( acmd_rst_b    ),  // Control - Reset
-        //.acmd_up_b  ( acmd_up_b     ),  // Control - New command received
+		  .acmd_up_b  ( acmd_up_b     ),  // Control - New command received
         .alr_b      ( alr_b         ),  // Left / Right
         .astart_b   ( astart_b      ),  // Start address
         .aend_b     ( aend_b        ),  // End   address
@@ -234,12 +240,12 @@ if( use_adpcm==1 ) begin: gen_adpcm
         .data       ( adpcmb_data   ),
         .roe_n      ( adpcmb_roe_n  ),
 
-        .pcm55_l    ( adpcmB_l      ),
-        .pcm55_r    ( adpcmB_r      )
+        .pcm55_l    ( adpcmBt_l      ),
+        .pcm55_r    ( adpcmBt_r      )
     );
 
     /* verilator tracing_on */
-    assign snd_sample   = zero;
+    assign snd_sample   = zero;        
     jt10_acc u_acc(
         .clk        ( clk           ),
         .clk_en     ( clk_en        ),
@@ -274,23 +280,23 @@ end else begin : gen_adpcm_no
 end
 endgenerate
 
-/* verilator tracing_on */
+/* verilator tracing_off */
 jt12_dout #(.use_ssg(use_ssg),.use_adpcm(use_adpcm)) u_dout(
 //    .rst_n          ( rst_n         ),
     .clk            ( clk           ),        // CPU clock
     .flag_A         ( flag_A        ),
     .flag_B         ( flag_B        ),
     .busy           ( busy          ),
-    .adpcma_flags   ( adpcma_flags  ),
-    .adpcmb_flag    ( adpcmb_flag   ),
+    .adpcma_flags   ( adpcma_flags & flag_mask[5:0] ),
+    .adpcmb_flag    ( adpcmb_flag & flag_mask[6]    ),
     .psg_dout       ( psg_dout      ),
     .addr           ( addr          ),
     .dout           ( dout          )
 );
 
 
-/* verilator tracing_on */
-jt12_mmr #(.use_ssg(use_ssg),.num_ch(num_ch),.use_pcm(use_pcm), .use_adpcm(use_adpcm), .mask_div(mask_div))
+/* verilator tracing_off */
+jt12_mmr #(.use_ssg(use_ssg),.num_ch(num_ch),.use_pcm(use_pcm), .use_adpcm(use_adpcm), .use_clkdiv(use_clkdiv))
     u_mmr(
     .rst        ( rst       ),
     .clk        ( clk       ),
@@ -346,8 +352,9 @@ jt12_mmr #(.use_ssg(use_ssg),.num_ch(num_ch),.use_pcm(use_pcm), .use_adpcm(use_a
     .astart_b   ( astart_b      ),  // Start address
     .aend_b     ( aend_b        ),  // End   address
     .adeltan_b  ( adeltan_b     ),  // Delta-N
-    .aeg_b      ( aeg_b         ),  // Envelope Generator Control
+    .aeg_b      ( aeg_b         ),  // Envelope Generator Control    
     .flag_ctl   ( flag_ctl      ),
+    .flag_mask  ( flag_mask     ),
     // Operator
     .xuse_prevprev1 ( xuse_prevprev1  ),
     .xuse_internal  ( xuse_internal   ),
@@ -392,20 +399,17 @@ jt12_mmr #(.use_ssg(use_ssg),.num_ch(num_ch),.use_pcm(use_pcm), .use_adpcm(use_a
     // PSG interace
     .psg_addr   ( psg_addr  ),
     .psg_data   ( psg_data  ),
-    .psg_wr_n   ( psg_wr_n  ),
-    .debug_bus  ( debug_bus ),
-    .div_setting(div_setting)
+    .psg_wr_n   ( psg_wr_n  )
 );
 
-/* verilator tracing_on */
-// YM2203 seems to use a fixed cen/3 clock for the timers, regardless
+/* verilator tracing_off */
+// YM2203 seems to use a fixed cen/3 clock for the timers, regardless 
 // of the prescaler setting
-wire timer_cen = fast_timers ? cen : clk_en;
-jt12_timers #(.num_ch(num_ch)) u_timers (
+wire timer_cen = num_ch==3 ? clk_en_2 : ( fast_timers ? cen : clk_en);
+jt12_timers u_timers(
     .clk        ( clk           ),
     .clk_en     ( timer_cen     ),
     .rst        ( rst           ),
-    .zero       ( zero          ),
     .value_A    ( value_A       ),
     .value_B    ( value_B       ),
     .load_A     ( load_A        ),
@@ -447,7 +451,7 @@ endgenerate
 `ifndef NOSSG
 generate
     if( use_ssg==1 ) begin : gen_ssg
-        jt49 #(.COMP(2'b01), .CLKDIV(JT49_DIV))
+        jt49 #(.COMP(2'b01), .CLKDIV(JT49_DIV)) 
             u_psg( // note that input ports are not multiplexed
             .rst_n      ( ~rst      ),
             .clk        ( clk       ),    // signal on positive edge
@@ -463,14 +467,13 @@ generate
             .dout       ( psg_dout  ),
             .sel        ( 1'b1      ),  // half clock speed
             // Unused:
-            .IOA_out    (           ),
-            .IOB_out    (           ),
-            .IOA_in     ( IOA_in    ),
-            .IOB_in     ( IOB_in    ),
-            .sample     (           )
+            .IOA_out    (),
+            .IOB_out    (),
+            .IOA_in     (8'd0),
+            .IOB_in     (8'd0)
         );
-        assign snd_left  = fm_snd_left  + { 1'b0, psg_snd[9:0],5'd0};
-        assign snd_right = fm_snd_right + { 1'b0, psg_snd[9:0],5'd0};
+        assign snd_left  = snd_enable[3] ? fm_snd_left  + { 1'b0, psg_snd[9:0],5'd0} : fm_snd_left;
+        assign snd_right = snd_enable[3] ? fm_snd_right + { 1'b0, psg_snd[9:0],5'd0} : fm_snd_right;
     end else begin : gen_nossg
         assign psg_snd  = 10'd0;
         assign snd_left = fm_snd_left;
@@ -491,7 +494,7 @@ endgenerate
 wire    [ 8:0]  op_result;
 wire    [13:0]  op_result_hd;
 `ifndef NOFM
-/* verilator tracing_on */
+/* verilator tracing_off */
 jt12_pg #(.num_ch(num_ch)) u_pg(
     .rst        ( rst           ),
     .clk        ( clk           ),
@@ -572,9 +575,9 @@ jt12_op #(.num_ch(num_ch)) u_op(
     .yuse_prev2     ( yuse_prev2    ),
     .zero           ( zero          ),
     .op_result      ( op_result     ),
-    .full_result    ( op_result_hd  )
+    .full_result    ( op_result_hdt  )
 );
-`else
+`else 
 assign op_result    = 'd0;
 assign op_result_hd = 'd0;
 `endif
@@ -614,7 +617,7 @@ generate
         wire signed [10:0] pcm_full;
         always @(*)
             pcm2 = en_hifi_pcm ? pcm_full[9:1] : pcm;
-
+            
         jt12_pcm_interpol #(.dw(11), .stepw(5)) u_pcm (
             .rst_n ( rst_pcm_n      ),
             .clk   ( clk            ),


### PR DESCRIPTION
This change assumes that this line from neogeodev is incorrect:
"Flags must be manually cleared, playing a new sample on the channel won't clear it and the channel will stay silent."
In the third party source ymfm_opn used in MAME, the last phrase ("and the channel will stay silent") is not implemented.  This change attempts to match the behavior of ymfm_opn.